### PR TITLE
Handle autocomplete gracefully

### DIFF
--- a/src/vue-hotkey/hotkey.js
+++ b/src/vue-hotkey/hotkey.js
@@ -205,6 +205,12 @@ const hotkey = {
         }
 
         Vue.prototype.$hotkey.handleEvent = function(keyEvent) {
+
+            // Ignore key events without a key property (caused by autocomplete)
+            if (!keyEvent.key) {
+                return
+            }
+
             // Do not process plain characters typed into contenteditable or input elements
             const keyId = toKeyId(keyEvent)
             if (keyId.length == 2 && document.activeElement &&


### PR DESCRIPTION
This PR fixes a small issue caused by autocompletion. 

When the browser shows an autocomplete dropdown and the user selects one of options, a keyevent is triggered without an actual key. Vue-hotkey tries to identify this empty key, causing a TypeError in the keyId method (keyEvent.key is null):

```javascript
function toKeyId(keyEvent) {
    let id = keyEvent.key.toLowerCase() + '_'
```

By adding an early check to verify whether an actual key was pressed, v-hotkey won't throw any error message when autocomplete is used.